### PR TITLE
🤖 Flag PRs that have been inactive

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: '30 15 * * mon'
+  - cron: '30 15 */2 * *'
 
 jobs:
   stale:
@@ -16,6 +16,6 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-stale: 14
-        stale-pr-message: 'This pull request has had no activity in more than 2 weeks. Calling out reviewers: ${{ github.event.pull_request.requested_reviewers }}'
+        days-before-stale: 2
+        stale-pr-message: 'This pull request has had no activity in more than 2 days. Calling out reviewers: ${{ github.event.pull_request.requested_reviewers }}'
         stale-pr-label: 'no-pr-activity'


### PR DESCRIPTION
 This is part of my learning journey with Github Actions, described on #13

# What problem(s) does this PR target?

If a Pull Request is not reviewed or touched after 14 days, we might need to remind people about it.

# How does this PR try to solve the question(s) above?

The Github action introduced here makes use of default [actions/stale](https://github.com/actions/stale) and will automatically:
- Check if there is any active PR that has not received any update in 2 weeks
- In case it finds any, it will send a msg to the PR
- This action will run on Mondays every week 

# How can you validate this PR?

- If you agree with the rule introduced above, approve this PR
- If you *don't agree*, write a comment to this PR and request changes

Closes #13 